### PR TITLE
Fix check_addr() to return either 0 or 1

### DIFF
--- a/src/common/utils.c
+++ b/src/common/utils.c
@@ -45,8 +45,8 @@ static const char *localhost_names_v6[] = {
 };
 
 /*
- * Return 1 if the given IP belongs in the af domain else return a negative
- * value.
+ * Return 1 if the given IP belongs in the af domain else return 0 if the
+ * given ip is not a valid address or the af value is unknown.
  */
 static int check_addr(const char *ip, int af)
 {
@@ -56,9 +56,10 @@ static int check_addr(const char *ip, int af)
 	assert(ip);
 
 	ret = inet_pton(af, ip, buf);
-	if (ret != 1) {
-		ret = -1;
-	}
+  if (ret == -1) {
+    /* Possible if the af value is unknown to inet_pton. */
+    ret = 0;
+  }
 
 	return ret;
 }

--- a/tests/unit/test_config-file.c
+++ b/tests/unit/test_config-file.c
@@ -104,13 +104,13 @@ static void test_config_file_read_invalid_values(void)
 
 	memset(&config, 0x0, sizeof(config));
 	ret = config_file_read(fixture("config4"), &config);
-	ok(ret == -1 &&
+	ok(ret == 0 &&
 		config.conf_file.tor_address == NULL,
 		"TorAddress invalid IPv4 returns -1");
 
 	memset(&config, 0x0, sizeof(config));
 	ret = config_file_read(fixture("config5"), &config);
-	ok(ret == -1 &&
+	ok(ret == 0 &&
 		config.conf_file.tor_address == NULL,
 		"TorAddress invalid IPv6 returns -1");
 

--- a/tests/unit/test_utils.c
+++ b/tests/unit/test_utils.c
@@ -36,10 +36,10 @@ static void test_is_address_ipv4(void)
 	ok(ret == 1, "Valid IPv4 address");
 
 	ret = utils_is_address_ipv4("127.0.0.256");
-	ok(ret == -1, "Invalid IPv4 address");
+	ok(ret == 0, "Invalid IPv4 address");
 
 	ret = utils_is_address_ipv4("::1");
-	ok(ret == -1, "Invalid IPv4 address when IPv6");
+	ok(ret == 0, "Invalid IPv4 address when IPv6");
 }
 
 static void test_is_address_ipv6(void)
@@ -55,10 +55,10 @@ static void test_is_address_ipv6(void)
 	ok(ret == 1, "Valid IPv6 address");
 
 	ret = utils_is_address_ipv6("2001:DB8:0:0:8:800:200C:G");
-	ok(ret == -1, "Invalid IPv6 address");
+	ok(ret == 0, "Invalid IPv6 address");
 
 	ret = utils_is_address_ipv6("192.168.0.1");
-	ok(ret == -1, "Invalid IPv6 address when IPv4");
+	ok(ret == 0, "Invalid IPv6 address when IPv4");
 }
 
 static void test_localhost_resolve(void)


### PR DESCRIPTION
This function is used by utils_is_address_ipv4/6 and has to return 0 on
error or 1 on success.

Fixes #20871

Signed-off-by: David Goulet <dgoulet@ev0ke.net>